### PR TITLE
Modify FitNonLinLSWithGSL to return Inf if GSL fitting routine fails

### DIFF
--- a/src/Math/Fitting.cxx
+++ b/src/Math/Fitting.cxx
@@ -222,7 +222,7 @@ Double_t FitNonLinLSNoGSL(const math_function fitfunc, const math_function *diff
           gsl_blas_ddot(res_gsl, res_gsl, &chi2);
         } else {
           /* Fit failed, return large chi^2 */
-          std::cerr << "gsl_multifit_nlinear_driver() call failed!";
+          std::cerr << "gsl_multifit_nlinear_driver() call failed!\n";
           chi2 = std::numeric_limits<Double_t>::infinity();
         }
         // store cond(J(x))

--- a/src/Math/Fitting.cxx
+++ b/src/Math/Fitting.cxx
@@ -217,12 +217,12 @@ Double_t FitNonLinLSNoGSL(const math_function fitfunc, const math_function *diff
         int err = gsl_multifit_nlinear_driver(maxiit, xtol, gtol, ftol, NULL, NULL, &info_gsl, workspace_gsl);
         gsl_set_error_handler(old_handler);
         // store final chi^2
-        if(err==0) {
+        if(err==GSL_SUCCESS) {
           /* Fitting was successful */
           gsl_blas_ddot(res_gsl, res_gsl, &chi2);
         } else {
           /* Fit failed, return large chi^2 */
-          std::cerr << "gsl_multifit_nlinear_driver() call failed!\n";
+          std::cerr << "gsl_multifit_nlinear_driver() call failed, err=" << err <<"\n";
           chi2 = std::numeric_limits<Double_t>::infinity();
         }
         // store cond(J(x))

--- a/src/Math/Fitting.h
+++ b/src/Math/Fitting.h
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_interp.h>
 #include <gsl/gsl_monte.h>
@@ -15,6 +16,7 @@
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_matrix.h>
 #include <gsl/gsl_blas.h>
+#include <gsl/gsl_errno.h>
 #ifdef HAVE_GSL22
 #include <gsl/gsl_multifit_nlinear.h>
 #endif


### PR DESCRIPTION
This modifies FitNonLinLSWithGSL so that when calling gsl_multifit_nlinear_driver() the default GSL error handler is temporarily disabled and instead it checks the return code and sets chi2=Inf if the fit fails.

This is to address https://github.com/pelahi/VELOCIraptor-STF/issues/77 .