### PR TITLE
(Bug fixed) off in FOF should be initialized to 6dim

### DIFF
--- a/src/KDTree/KDFOF.cxx
+++ b/src/KDTree/KDFOF.cxx
@@ -72,7 +72,7 @@ namespace NBody
                 //within a distance fdist2, marks all particles using their IDS and pGroup array
                 //adjusts the Fifo array, iTail and pLen.
                 //first set offset to zero when beginning node search
-                for (int j = 0; j < 3; j++) off[j] = 0.0;
+                for (int j = 0; j < 6; j++) off[j] = 0.0;
                 if (period==NULL) root->FOFSearchBall(0.0,fdist2,iGroup,numparts,bucket,pGroup,pLen,pHead,pTail,pNext,pBucketFlag, Fifo,iTail,off,iid);
                 else root->FOFSearchBallPeriodic(0.0,fdist2,iGroup,numparts,bucket,pGroup,pLen,pHead,pTail,pNext,pBucketFlag, Fifo,iTail,off,period,iid);
             }


### PR DESCRIPTION
KDTree::FOF routine is used in 6D search as well as in 3D search.
Thus, the 'off' variable should be set to be 0 into the 6th component.
Otherwise, it results in a wrong calculation of 'rd' in FOFSearchBall when the split-dimension is one of the velocity dimensions.

Sometimes, the wrong implementation was seen to make a half more visiting to split/leaf nodes mostly for massive FOF halos (i.e., 2 times slower than originally intended).